### PR TITLE
Workflow for updating from official repo (resubmission)

### DIFF
--- a/.github/workflows/update-mirror.yml
+++ b/.github/workflows/update-mirror.yml
@@ -1,0 +1,23 @@
+name: Update mirror
+
+on:
+  schedule:
+    - cron: '0 */2 * * *'
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Update mirror
+        run: |
+          BRANCH="$(git branch --show-current)"
+          git remote add upstream git://git.kitenet.net/git-annex
+          git pull --tags upstream "$BRANCH"
+          git push --tags origin "$BRANCH"
+
+# vim:set sts=2:

--- a/.github/workflows/update-mirror.yml
+++ b/.github/workflows/update-mirror.yml
@@ -12,12 +12,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: upstream/master
 
       - name: Update mirror
         run: |
-          BRANCH="$(git branch --show-current)"
           git remote add upstream git://git.kitenet.net/git-annex
-          git pull --tags upstream "$BRANCH"
-          git push --tags origin "$BRANCH"
+          git pull --tags upstream upstream/master
+          git checkout master
+          git merge upstream/master
+          git push --tags origin master upstream/master
 
 # vim:set sts=2:

--- a/.github/workflows/update-mirror.yml
+++ b/.github/workflows/update-mirror.yml
@@ -18,8 +18,6 @@ jobs:
         run: |
           git remote add upstream git://git.kitenet.net/git-annex
           git pull --tags upstream upstream/master
-          git checkout master
-          git merge upstream/master
-          git push --tags origin master upstream/master
+          git push --tags origin upstream/master
 
 # vim:set sts=2:

--- a/.github/workflows/update-mirror.yml
+++ b/.github/workflows/update-mirror.yml
@@ -16,8 +16,8 @@ jobs:
 
       - name: Update mirror
         run: |
-          git remote add upstream git://git.kitenet.net/git-annex
-          git pull --tags upstream upstream/master
+          git remote add official git://git.kitenet.net/git-annex
+          git pull --tags official upstream/master
           git push --tags origin upstream/master
 
 # vim:set sts=2:


### PR DESCRIPTION
Closes #1.

Resubmitting #4 because the force-push to master made GitHub close the original PR.