### PR TITLE
Send e-mail to jwodder when scheduled runs fail

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -94,6 +94,22 @@ jobs:
           name: git-annex-macos-dmg_${{ steps.build-version.outputs.version }}
           path: tmp/git-annex_*.dmg
 
+      - name: Send e-mail on failed scheduled run
+        if: "failure() && github.event_name == 'schedule'"
+        uses: dawidd6/action-send-mail@v2
+        with:
+          server_address: ${{ secrets.NOTIFY_SMTP_HOST }}
+          server_port: ${{ secrets.NOTIFY_SMTP_PORT }}
+          username: ${{ secrets.NOTIFY_SMTP_USERNAME }}
+          password: ${{ secrets.NOTIFY_SMTP_PASSWORD }}
+          from: GitHub Actions Notifications
+          to: ${{ secrets.NOTIFY_RECIPIENT }}
+          subject: '[${{ github.repository }}] Scheduled build on macOS failed!'
+          body: |
+            A scheduled build of git-annex for macOS failed!
+
+            See <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}> for more information.
+
   test-annex:
     runs-on: macos-latest
     needs: build-package
@@ -152,6 +168,24 @@ jobs:
           export | grep -e crippledfs || :
 
           git annex test
+
+      - name: Send e-mail on failed scheduled run
+        if: "failure() && github.event_name == 'schedule'"
+        uses: dawidd6/action-send-mail@v2
+        with:
+          server_address: ${{ secrets.NOTIFY_SMTP_HOST }}
+          server_port: ${{ secrets.NOTIFY_SMTP_PORT }}
+          username: ${{ secrets.NOTIFY_SMTP_USERNAME }}
+          password: ${{ secrets.NOTIFY_SMTP_PASSWORD }}
+          from: GitHub Actions Notifications
+          to: ${{ secrets.NOTIFY_RECIPIENT }}
+          subject: '[${{ github.repository }}] Scheduled tests of macOS build failed!'
+          body: |
+            The tests for a scheduled build of git-annex for macOS failed for the following matrix:
+
+            ${{ toJSON(matrix) }}
+
+            See <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}> for more information.
 
   test-annex-more:
     runs-on: macos-latest

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -109,6 +109,22 @@ jobs:
           name: git-annex-debianstandalone-packages_${{ steps.build-version.outputs.version }}
           path: git-annex[-_]*.*
 
+      - name: Send e-mail on failed scheduled run
+        if: "failure() && github.event_name == 'schedule'"
+        uses: dawidd6/action-send-mail@v2
+        with:
+          server_address: ${{ secrets.NOTIFY_SMTP_HOST }}
+          server_port: ${{ secrets.NOTIFY_SMTP_PORT }}
+          username: ${{ secrets.NOTIFY_SMTP_USERNAME }}
+          password: ${{ secrets.NOTIFY_SMTP_PASSWORD }}
+          from: GitHub Actions Notifications
+          to: ${{ secrets.NOTIFY_RECIPIENT }}
+          subject: '[${{ github.repository }}] Scheduled build on Ubuntu failed!'
+          body: |
+            A scheduled build of git-annex for Ubuntu failed!
+
+            See <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}> for more information.
+
   test-annex:
     runs-on: ubuntu-latest
     needs: build-package
@@ -176,6 +192,24 @@ jobs:
           export | grep -e crippledfs || :
 
           git annex test
+
+      - name: Send e-mail on failed scheduled run
+        if: "failure() && github.event_name == 'schedule'"
+        uses: dawidd6/action-send-mail@v2
+        with:
+          server_address: ${{ secrets.NOTIFY_SMTP_HOST }}
+          server_port: ${{ secrets.NOTIFY_SMTP_PORT }}
+          username: ${{ secrets.NOTIFY_SMTP_USERNAME }}
+          password: ${{ secrets.NOTIFY_SMTP_PASSWORD }}
+          from: GitHub Actions Notifications
+          to: ${{ secrets.NOTIFY_RECIPIENT }}
+          subject: '[${{ github.repository }}] Scheduled tests of Ubuntu build failed!'
+          body: |
+            The tests for a scheduled build of git-annex for Ubuntu failed for the following matrix:
+
+            ${{ toJSON(matrix) }}
+
+            See <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}> for more information.
 
   test-annex-more:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -130,6 +130,22 @@ jobs:
             git-annex-installer_*.exe
             dist\build-version
 
+      - name: Send e-mail on failed scheduled run
+        if: "failure() && github.event_name == 'schedule'"
+        uses: dawidd6/action-send-mail@v2
+        with:
+          server_address: ${{ secrets.NOTIFY_SMTP_HOST }}
+          server_port: ${{ secrets.NOTIFY_SMTP_PORT }}
+          username: ${{ secrets.NOTIFY_SMTP_USERNAME }}
+          password: ${{ secrets.NOTIFY_SMTP_PASSWORD }}
+          from: GitHub Actions Notifications
+          to: ${{ secrets.NOTIFY_RECIPIENT }}
+          subject: '[${{ github.repository }}] Scheduled build on Windows failed!'
+          body: |
+            A scheduled build of git-annex for Windows failed!
+
+            See <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}> for more information.
+
   test-annex:
     runs-on: windows-2016
     needs: build-package
@@ -164,6 +180,22 @@ jobs:
         run: |
           cd $HOME
           timeout 1800 git annex test
+
+      - name: Send e-mail on failed scheduled run
+        if: "failure() && github.event_name == 'schedule'"
+        uses: dawidd6/action-send-mail@v2
+        with:
+          server_address: ${{ secrets.NOTIFY_SMTP_HOST }}
+          server_port: ${{ secrets.NOTIFY_SMTP_PORT }}
+          username: ${{ secrets.NOTIFY_SMTP_USERNAME }}
+          password: ${{ secrets.NOTIFY_SMTP_PASSWORD }}
+          from: GitHub Actions Notifications
+          to: ${{ secrets.NOTIFY_RECIPIENT }}
+          subject: '[${{ github.repository }}] Scheduled tests of Windows build failed!'
+          body: |
+            The tests for a scheduled build of git-annex for Windows failed!
+
+            See <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}> for more information.
 
   test-datalad:
     runs-on: windows-2016


### PR DESCRIPTION
If I'm the one who has to monitor scheduled builds for failures, then I'm going to set up automation.

(I've already added the necessary secrets to the repo.)