### PR TITLE
Build macOS DMG with USE_SYSTEM_LIBS=1

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -79,7 +79,7 @@ jobs:
             cache-stack-macos-
 
       - name: Build git-annex
-        run: make osxapp
+        run: make osxapp USE_SYSTEM_LIBS=1
 
       - name: Add version to DMG name
         run: |


### PR DESCRIPTION
Ref: https://git-annex.branchable.com/bugs/Build__47__OSXMkLibs.hs_does_not_resolve___64__loader__95__path/#comment-db264b736b5e402473ef09246c434ed4