### PR TITLE
RF(BF somewhat): use python 3.8 not 3.7 through all OSes

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -356,10 +356,10 @@ jobs:
           git config --global user.email "test@github.land"
           git config --global user.name "GitHub Almighty"
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install ${{ matrix.version }} Datalad
         run: |
@@ -382,7 +382,7 @@ jobs:
         run: |
           mkdir -p __testhome__
           cd __testhome__
-          python -m nose -s -v datalad
+          python -m nose -s -v --traverse-namespace datalad
 
       - name: Set final PR status
         if: always() && github.event.inputs.pr != ''

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -350,10 +350,10 @@ jobs:
           git config --global user.email "test@github.land"
           git config --global user.name "GitHub Almighty"
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install ${{ matrix.version }} Datalad
         run: |
@@ -376,7 +376,7 @@ jobs:
         run: |
           mkdir -p __testhome__
           cd __testhome__
-          python -m nose -s -v datalad
+          python -m nose -s -v --traverse-namespace datalad
 
       - name: Set final PR status
         if: always() && github.event.inputs.pr != ''

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -340,10 +340,10 @@ jobs:
           git config --global user.email "test@github.land"
           git config --global user.name "GitHub Almighty"
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install ${{ matrix.version }} Datalad
         run: |
@@ -366,7 +366,7 @@ jobs:
         run: |
           mkdir -p __testhome__
           cd __testhome__
-          python -m nose -s -v datalad
+          python -m nose -s -v --traverse-namespace datalad
 
       - name: Set final PR status
         if: always() && github.event.inputs.pr != ''

--- a/.github/workflows/template/build-{{ostype}}.yaml.j2
+++ b/.github/workflows/template/build-{{ostype}}.yaml.j2
@@ -577,10 +577,10 @@ jobs:
           git config --global user.email "test@github.land"
           git config --global user.name "GitHub Almighty"
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install ${{ matrix.version }} Datalad
         run: |

--- a/.github/workflows/template/build-{{ostype}}.yaml.j2
+++ b/.github/workflows/template/build-{{ostype}}.yaml.j2
@@ -603,7 +603,7 @@ jobs:
         run: |
           mkdir -p __testhome__
           cd __testhome__
-          python -m nose -s -v datalad
+          python -m nose -s -v --traverse-namespace datalad
 
       - name: Set final PR status
         if: always() && github.event.inputs.pr != ''


### PR DESCRIPTION
    We are running into failing tests on Windows which seems to attribute to
    Python version < 3.8, so let's just boost our python here to 3.8, as our
    purpose here is more of (integration) testing git-annex than DataLad per se
