### PR TITLE
Match "Location:" header case-insensitively

### DIFF
--- a/.github/workflows/tools/download-latest-artifact
+++ b/.github/workflows/tools/download-latest-artifact
@@ -41,7 +41,7 @@ definedOrExit "${ARCHIVE_DOWNLOAD_URL}" "Unable to get archive_download_url" ${J
 
 call_curl -i "${ARCHIVE_DOWNLOAD_URL}" >| ${JOBS_DOWNLOAD}
 echo "Getting download url from ${ARCHIVE_DOWNLOAD_URL}"
-DOWNLOAD_URL=$(grep -oP 'Location: \K.+' < ${JOBS_DOWNLOAD})
+DOWNLOAD_URL=$(grep -ioP 'Location: \K.+' < ${JOBS_DOWNLOAD})
 definedOrExit "${DOWNLOAD_URL}" "Unable to get Location header with download url" ${JOBS_DOWNLOAD}
 DOWNLOAD_URL=${DOWNLOAD_URL%$'\r'}
 rm -f ${JOBS_DOWNLOAD}


### PR DESCRIPTION
See https://github.com/datalad/datalad-extensions/pull/77 for more information.  The lack of this patch is currently causing the Windows builds to fail.