### PR TITLE
RF: Disable SSH testing on OSX, enable on linux everywhere

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -340,21 +340,6 @@ jobs:
           hdiutil detach /Volumes/git-annex/
           echo /Applications/git-annex.app/Contents/MacOS >> "$GITHUB_PATH"
 
-      - name: Set up SSH target
-        shell: bash
-        # TODO: Drop the release condition once 0.13.2 is released.
-        run: |
-          if [ "${{ matrix.version }}" != "release" ]; then
-            # coreutils provides a readlink that supports `-f`
-            brew install coreutils docker docker-machine
-            docker-machine --github-api-token="${{ secrets.GITHUB_TOKEN }}" create --driver virtualbox default
-            eval "$(docker-machine env default)"
-            export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
-            curl -fSsL \
-              https://raw.githubusercontent.com/datalad/datalad/master/tools/ci/prep-travis-forssh.sh \
-              | bash
-            echo DATALAD_TESTS_SSH=1 >> "$GITHUB_ENV"
-          fi
 
       - name: Set up environment
         run: |

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -342,14 +342,12 @@ jobs:
 
       - name: Set up SSH target
         shell: bash
-        # TODO: Drop the release condition once 0.13.2 is released.
         run: |
-          if [ "${{ matrix.version }}" != "release" ]; then
-            curl -fSsL \
-              https://raw.githubusercontent.com/datalad/datalad/master/tools/ci/prep-travis-forssh.sh \
-              | bash
-            echo DATALAD_TESTS_SSH=1 >> "$GITHUB_ENV"
-          fi
+          curl -fSsL \
+            https://raw.githubusercontent.com/datalad/datalad/master/tools/ci/prep-travis-forssh.sh \
+            | bash
+          echo DATALAD_TESTS_SSH=1 >> "$GITHUB_ENV"
+
 
       - name: Set up environment
         run: |

--- a/.github/workflows/template/build-{{ostype}}.yaml.j2
+++ b/.github/workflows/template/build-{{ostype}}.yaml.j2
@@ -510,25 +510,25 @@ jobs:
           {{step}}
           {% endfor %}
 
-    {% if ostype == "ubuntu" or ostype == "macos" %}
+    {% if ostype == "ubuntu" %}
+    {# TODO: return for macos! https://github.com/datalad/git-annex/issues/42
+      {% if ostype == "ubuntu"  or ostype == "macos" %} #}
       - name: Set up SSH target
         shell: bash
-        # TODO: Drop the release condition once 0.13.2 is released.
         run: |
-          if [ "${{ matrix.version }}" != "release" ]; then
-            {% if ostype == "macos" %}
-            # coreutils provides a readlink that supports `-f`
-            brew install coreutils docker docker-machine
-            docker-machine --github-api-token="${{ secrets.GITHUB_TOKEN }}" create --driver virtualbox default
-            eval "$(docker-machine env default)"
-            export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
-            {% endif %}
-            curl -fSsL \
-              https://raw.githubusercontent.com/datalad/datalad/master/tools/ci/prep-travis-forssh.sh \
-              | bash
-            echo DATALAD_TESTS_SSH=1 >> "$GITHUB_ENV"
-          fi
-    {% elif ostype == "windows" %}
+          {% if ostype == "macos" %}
+          # coreutils provides a readlink that supports `-f`
+          brew install coreutils docker docker-machine
+          docker-machine --github-api-token="${{ secrets.GITHUB_TOKEN }}" create --driver virtualbox default
+          eval "$(docker-machine env default)"
+          export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+          {% endif %}
+          curl -fSsL \
+            https://raw.githubusercontent.com/datalad/datalad/master/tools/ci/prep-travis-forssh.sh \
+            | bash
+          echo DATALAD_TESTS_SSH=1 >> "$GITHUB_ENV"
+
+   {% elif ostype == "windows" %}
       - name: Define test host alias
         shell: cmd
         run: |


### PR DESCRIPTION
    For not yet known reason we have a problem instantiating a proper docker
    container on OSX for ssh testing.  Also I found some logic which we
    should have removed after datalad 0.13.2 release while establishing
    that docker container on osx and linux -- so I removed conditional
    
    Re OSX: see https://github.com/datalad/git-annex/issues/42