### PR TITLE
Enable exception logging

### DIFF
--- a/.github/workflows/template/build-{{ostype}}.yaml.j2
+++ b/.github/workflows/template/build-{{ostype}}.yaml.j2
@@ -620,6 +620,7 @@ jobs:
           {% endif %}
           git config --global user.email "test@github.land"
           git config --global user.name "GitHub Almighty"
+          git config --global datalad.log.exc "1"
 
       - name: Set up Python 3.7
         uses: actions/setup-python@v1


### PR DESCRIPTION
Exception logging is now disabled by default in datalad, but tests are
still making detailed assertions about what is logged how. Running them
requires that config to be set.

Closes https://github.com/datalad/datalad/issues/5758

I'm not quite sure how the github workflow are supposed to work in this repo. Seems to be generated, so I included the setting in the template file. Don't see what's triggering the generation, though. Anything I should add, @jwodder , @yarikoptic ?