### PR TITLE
Test for nfs-home not nfs-tmp

### DIFF
--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -187,7 +187,7 @@ jobs:
     needs: build-package
     strategy:
       matrix:
-        flavor: ["normal", "crippled-tmp", "crippled-home", "nfs-tmp"]
+        flavor: ["normal", "crippled-tmp", "crippled-home", "nfs-home"]
       fail-fast: false
     steps:
       - name: Checkout this repository

--- a/.github/workflows/template/specs.yml
+++ b/.github/workflows/template/specs.yml
@@ -7,9 +7,8 @@
     DEB_SIGN_KEYID: 13A1093296154584245E0300C98FC49D36DAB17F
     DEB_BUILD_OPTIONS: nocheck
     bbuild_log: git-annex-build.log
-  test_annex_flavors: [normal, crippled-tmp, crippled-home, nfs-tmp]
-    # TODO: Add nfs-home
-    # https://git-annex.branchable.com/bugs/running_tests_on_NFS_HOME_does_not_exit_cleanly__58___gpgtmp/
+  test_annex_flavors: [normal, crippled-tmp, crippled-home, nfs-home]
+    # nfs-tmp was removed/replaced with nfs-home since annex started to use TMPDIR for gpg, and tests started to fail
   artifact_basename: git-annex-debianstandalone-packages
   artifact_install_steps:
     - sudo dpkg -i git-annex*.deb


### PR DESCRIPTION
Here is the details I was to submit against git-annex, but I think the
change was "intended" and most likely it is not worth striving to support
NFS-mounted TMPDIR.

<details>
<summary> details I was going to post against git-annex</summary>

### Please describe the problem.

Mentioned that "linux build" on https://github.com/datalad/git-annex/ is red. Looking inside a [sample run log](https://github.com/datalad/git-annex/runs/4029945729?check_suite_focus=true)

```
    crypto:                                               FAIL
      Exception: /tmp/nfsmount/gpgtmpvv9ZBy/2/.nfs0000000000103f760000001e: removeDirectoryRecursive:removeContentsRecursive:removePathRecursive:removeContentsRecursive:removePathRecursive:removeLink: resource busy (Device or resource busy)
```

and it seems to be a regression since it seems flipped recently:

```
(git)smaug:/mnt/datasets/datalad/ci/git-annex[master]builds/2021
$> ls -ld 10/cron-*/build-ubuntu.yaml-*/4_test-annex\ \(nfs-tmp\).txt
...
-rw-r--r-- 1 datalad datalad 132371 Oct 11 00:55 10/cron-20211011/build-ubuntu.yaml-445-5b6a6bff-success/4_test-annex\ (nfs-tmp).txt
-rw-r--r-- 1 datalad datalad 132100 Oct 12 00:55 10/cron-20211012/build-ubuntu.yaml-447-5b6a6bff-success/4_test-annex\ (nfs-tmp).txt
-rw-r--r-- 1 datalad datalad 134683 Oct 13 00:55 10/cron-20211013/build-ubuntu.yaml-448-5b6a6bff-failed/4_test-annex\ (nfs-tmp).txt
-rw-r--r-- 1 datalad datalad 134663 Oct 14 00:55 10/cron-20211014/build-ubuntu.yaml-449-5b6a6bff-failed/4_test-annex\ (nfs-tmp).txt

$> grep 'Device or resource busy' 10/cron-202110{12,13}/build-ubuntu.yaml-*/4_test-annex\ \(nfs-tmp\).txt
10/cron-20211013/build-ubuntu.yaml-448-5b6a6bff-failed/4_test-annex (nfs-tmp).txt:2021-10-13T02:57:06.1081181Z       Exception: /tmp/nfsmount/gpgtmpI0oml8/2/.nfs0000000000085f1900000006: removeDirectoryRecursive:removeContentsRecursive:removePathRecursive:removeContentsRecursive:removePathRecursive:removeLink: resource busy (Device or resource busy)
10/cron-20211013/build-ubuntu.yaml-448-5b6a6bff-failed/4_test-annex (nfs-tmp).txt:2021-10-13T02:58:19.5420384Z       Exception: /tmp/nfsmount/gpgtmp8aENK4/2/.nfs0000000000085f230000000f: removeDirectoryRecursive:removeContentsRecursive:removePathRecursive:removeContentsRecursive:removePathRecursive:removeLink: resource busy (Device or resource busy)
10/cron-20211013/build-ubuntu.yaml-448-5b6a6bff-failed/4_test-annex (nfs-tmp).txt:2021-10-13T02:59:28.0135977Z       Exception: /tmp/nfsmount/gpgtmpgKRtz5/2/.nfs0000000000085f2b00000016: removeDirectoryRecursive:removeContentsRecursive:removePathRecursive:removeContentsRecursive:removePathRecursive:removeLink: resource busy (Device or resource busy)

```

here are the versions of annex
```
$> grep 'name: .*8.2021' 10/cron-202110{12,13}/build-ubuntu.yaml-*/4_test-annex\ \(nfs-tmp\).txt
10/cron-20211012/build-ubuntu.yaml-447-5b6a6bff-success/4_test-annex (nfs-tmp).txt:2021-10-12T02:54:36.8888788Z   name: git-annex-debianstandalone-packages_8.20211011+git8-gb7d5d54b0_amd64
10/cron-20211013/build-ubuntu.yaml-448-5b6a6bff-failed/4_test-annex (nfs-tmp).txt:2021-10-13T02:54:40.5415602Z   name: git-annex-debianstandalone-packages_8.20211011+git11-g3b5ac2d0d_amd64
```

so relates to:

```
$> git diff b7d5d54b0..3b5ac2d0d | head -n12
diff --git a/CHANGELOG b/CHANGELOG
index c9202beb2..a4ff6fb61 100644
--- a/CHANGELOG
+++ b/CHANGELOG
   * Negotiate P2P protocol version with tor remotes, allowing
     use of protocol version 1. This negotiation is not supported
     by versions of git-annex older than 6.20180312.
+  * test: Put gpg temp home directory in system temp directory,
+    not filesystem being tested.

  -- Joey Hess <id@joeyh.name>  Mon, 11 Oct 2021 14:09:13 -0400
```

</details>

not sure though if testing under NFS HOME would also go through smoothly -- e.g. we are still running into NFS issues in testing datalad there