### PR TITLE
No interactive cred query in CI setup

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -21,6 +21,7 @@ defaults:
 
 env:
   LANG: C
+  GIT_ASKPASS: True
 
 jobs:
   build-package:
@@ -260,6 +261,7 @@ jobs:
           # Do it after we possibly setup HOME
           git config --global user.email "test@github.land"
           git config --global user.name "GitHub Almighty"
+          git config --global core.askPass ""
 
           cd $HOME
           export | grep -e crippledfs || :

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -23,6 +23,7 @@ env:
   LANG: C
   DEB_SIGN_KEYID: 13A1093296154584245E0300C98FC49D36DAB17F
   DEB_BUILD_OPTIONS: nocheck
+  GIT_ASKPASS: True
   bbuild_log: git-annex-build.log
 
 jobs:
@@ -259,6 +260,7 @@ jobs:
           # Do it after we possibly setup HOME
           git config --global user.email "test@github.land"
           git config --global user.name "GitHub Almighty"
+          git config --global core.askPass ""
 
           cd $HOME
           export | grep -e crippledfs || :

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -21,6 +21,7 @@ defaults:
 
 env:
   LANG: C.utf-8
+  GIT_ASKPASS: True
 
 jobs:
   build-package:
@@ -253,6 +254,7 @@ jobs:
           # Do it after we possibly setup HOME
           git config --global user.email "test@github.land"
           git config --global user.name "GitHub Almighty"
+          git config --global core.askPass ""
 
           cd $HOME
           export | grep -e crippledfs || :

--- a/.github/workflows/template/build-{{ostype}}.yaml.j2
+++ b/.github/workflows/template/build-{{ostype}}.yaml.j2
@@ -420,6 +420,7 @@ jobs:
           # Do it after we possibly setup HOME
           git config --global user.email "test@github.land"
           git config --global user.name "GitHub Almighty"
+          git config --global core.askPass ""
 
           cd $HOME
           export | grep -e crippledfs || :

--- a/.github/workflows/template/specs.yml
+++ b/.github/workflows/template/specs.yml
@@ -6,6 +6,7 @@
     LANG: C
     DEB_SIGN_KEYID: 13A1093296154584245E0300C98FC49D36DAB17F
     DEB_BUILD_OPTIONS: nocheck
+    GIT_ASKPASS: true
     bbuild_log: git-annex-build.log
   test_annex_flavors: [normal, crippled-tmp, crippled-home, nfs-home]
     # nfs-tmp was removed/replaced with nfs-home since annex started to use TMPDIR for gpg, and tests started to fail
@@ -20,6 +21,7 @@
   runs_on: macos-10.15
   env:
     LANG: C
+    GIT_ASKPASS: true
   test_annex_flavors: [normal, crippled-tmp]
     # TODO: Add "crippled-home" back in once
     # <https://git-annex.branchable.com/bugs/gets_stuck_in_Remote_Tests___40____63____41___while_running_on_OSX_with_HOME_on_crippled_FS/?updated>
@@ -43,6 +45,7 @@
   runs_on: windows-2016
   env:
     LANG: C.utf-8
+    GIT_ASKPASS: true
   test_annex_flavors: []
   artifact_basename: git-annex-windows-installer
   artifact_install_steps:


### PR DESCRIPTION
@yarikoptic @jwodder 
Not sure how this is intended in this repo. Is `make` called automatically? Do I need to add a respective commit? Can't see a run-record to reuse.

Fixes https://github.com/datalad/datalad/issues/6442