### PR TITLE
Refresh image building workflow

### DIFF
--- a/.github/workflows/build-linux-buildenv.yaml
+++ b/.github/workflows/build-linux-buildenv.yaml
@@ -6,9 +6,11 @@ on:
       - master
     paths:
       - .github/workflows/tools/containers/buildenv-git-annex-buster/*
+      - .github/workflows/build-linux-buildenv.yaml
   pull_request:
     paths:
       - .github/workflows/tools/containers/buildenv-git-annex-buster/*
+      - .github/workflows/build-linux-buildenv.yaml
 
 jobs:
   build:

--- a/.github/workflows/tools/containers/buildenv-git-annex-buster/Dockerfile
+++ b/.github/workflows/tools/containers/buildenv-git-annex-buster/Dockerfile
@@ -9,7 +9,7 @@ RUN echo 'Acquire::http::Dl-Limit "1000";' >| /etc/apt/apt.conf.d/20snapshots \
     && echo 'Acquire::Retries "5";' >> /etc/apt/apt.conf.d/20snapshots
 
 RUN set -ex; \
-    nd_freeze 20211001; \
+    nd_freeze 20220327; \
     sed -i -e 's,^#deb-src,deb-src,g' /etc/apt/sources.list.d/neurodebian.sources.list; \
     apt-get update -qq; \
     export DEBIAN_FRONTEND=noninteractive; \


### PR DESCRIPTION
Minor tuning ups to see what is happening with this workflow and why we probably didn't get image updated per https://github.com/datalad/git-annex/issues/110 

note: we build/push image even from PRs if I got it right while looking at workflow -- we might want to disable that. Filed #112 