### PR TITLE
ENH: clients/testlib.sh inform on how long it took before trap exit

### DIFF
--- a/clients/testlib.sh
+++ b/clients/testlib.sh
@@ -2,6 +2,6 @@ function workdir_base {
     WORKDIR_BASE="$1"
     mkdir -p "$WORKDIR_BASE/$BUILDNO"
     SECONDS=0
-    trap 'echo "Elapsed $SECONDS seconds" && cd "$WORKDIR_BASE" && chmod -R +w "$BUILDNO" && rm -rf "$BUILDNO"' EXIT
+    trap 'echo "Elapsed time: $SECONDS seconds" && cd "$WORKDIR_BASE" && chmod -R +w "$BUILDNO" && rm -rf "$BUILDNO"' EXIT
     cd "$WORKDIR_BASE/$BUILDNO"
 }


### PR DESCRIPTION
using bash (works in zsh too) trick.

Needed since I don't know for sure if exit due to timeout or some other reason.  E.g. we got job on smaug exit with 124, most likely due to time out since that is the exit code it uses, but still -- would be worth knowing IMHO for sure how long it took.  also could be handy to judge if tests slowed down etc through time via a simple grep through historical notes etc.