### PR TITLE
Update macOS workflows to macOS 11

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build-package:
-    runs-on: macos-10.15
+    runs-on: macos-11
     outputs:
       build-version: ${{ steps.build-version.outputs.version }}
     steps:
@@ -183,7 +183,7 @@ jobs:
     strategy:
       matrix:
         flavor: ["normal", "crippled-tmp", "custom-config1"]
-        os: [macos-10.15]
+        os: [macos-11]
         include: [{"flavor": "normal", "os": "macos-latest"}]
       fail-fast: false
     steps:
@@ -307,7 +307,7 @@ jobs:
             See <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}> for more information.
 
   test-annex-more:
-    runs-on: macos-10.15
+    runs-on: macos-11
     needs: build-package
     steps:
       - name: Checkout this repository
@@ -360,7 +360,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test-datalad:
-    runs-on: macos-10.15
+    runs-on: macos-11
     needs: build-package
     strategy:
       matrix:

--- a/.github/workflows/template/specs.yml
+++ b/.github/workflows/template/specs.yml
@@ -18,7 +18,7 @@
 - ostype: macos
   osname: macOS
   cron_hour: '01'
-  runs_on: macos-10.15
+  runs_on: macos-11
   env:
     LANG: C
   test_annex_flavors: [normal, crippled-tmp, custom-config1]


### PR DESCRIPTION
Our macOS workflows currently use 10.15, [which GitHub will stop supporting on December 1](https://github.com/actions/virtual-environments/issues/5583).