### PR TITLE
Set action step outputs via $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -71,7 +71,7 @@ jobs:
           version="$(git describe "$BUILD_COMMIT" | sed -e 's/-/+git/')"
           arch=x64
           echo "Building $version"
-          echo "::set-output name=version::${version}_$arch"
+          echo "version=${version}_$arch" >> "$GITHUB_OUTPUT"
 
       - name: Apply local patches
         run: .github/workflows/tools/apply-patches patches

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -78,7 +78,7 @@ jobs:
           version="$(git describe "$BUILD_COMMIT" | sed -e 's/-/+git/')"
           arch="$(dpkg --print-architecture)"
           echo "Building $version"
-          echo "::set-output name=version::${version}_$arch"
+          echo "version=${version}_$arch" >> "$GITHUB_OUTPUT"
 
       - name: Apply local patches
         run: .github/workflows/tools/apply-patches patches

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -81,7 +81,7 @@ jobs:
           version="$(git describe "$BUILD_COMMIT" | sed -e 's/-/+git/')"
           arch=x64
           echo "Building $version"
-          echo "::set-output name=version::${version}_$arch"
+          echo "version=${version}_$arch" >> "$GITHUB_OUTPUT"
 
       - name: Apply local patches
         run: .github/workflows/tools/apply-patches patches

--- a/.github/workflows/daily-status.yaml
+++ b/.github/workflows/daily-status.yaml
@@ -23,7 +23,7 @@ jobs:
         id: content
         run: |
           subject="$(python -m pip-run -q -- .github/workflows/tools/daily-status.py)"
-          echo "::set-output name=subject::$subject"
+          echo "subject=$subject" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.DATALAD_GITHUB_TOKEN }}
 

--- a/.github/workflows/template/build-{{ostype}}.yaml.j2
+++ b/.github/workflows/template/build-{{ostype}}.yaml.j2
@@ -107,7 +107,7 @@ jobs:
           arch=x64
           {% endif %}
           echo "Building $version"
-          echo "::set-output name=version::${version}_$arch"
+          echo "version=${version}_$arch" >> "$GITHUB_OUTPUT"
 
       - name: Apply local patches
         run: .github/workflows/tools/apply-patches patches


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for more information.