### PR TITLE
Update GitHub Actions action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "[gh-actions]"
+      include: scope

--- a/.github/workflows/build-linux-buildenv.yaml
+++ b/.github/workflows/build-linux-buildenv.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build image
         run: docker build -t datalad/buildenv-git-annex-buster .

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -29,7 +29,7 @@ jobs:
       build-version: ${{ steps.build-version.outputs.version }}
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -93,7 +93,7 @@ jobs:
         run: stack setup
 
       - name: Enable Stack cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.stack
           key: cache-stack-macos-${{ hashFiles('stack.yaml.lock') }}-${{ hashFiles('git-annex.cabal') }}
@@ -115,7 +115,7 @@ jobs:
              git-annex_"${{ steps.build-version.outputs.version }}".dmg
 
       - name: Upload packages
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: git-annex-macos-dmg_${{ steps.build-version.outputs.version }}
           path: |
@@ -162,7 +162,7 @@ jobs:
 
       - name: Send e-mail on failed scheduled run
         if: "failure() && github.event_name == 'schedule'"
-        uses: dawidd6/action-send-mail@v2
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: ${{ secrets.NOTIFY_SMTP_HOST }}
           server_port: ${{ secrets.NOTIFY_SMTP_PORT }}
@@ -187,7 +187,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create pending PR status
         if: github.event.inputs.pr != ''
@@ -201,7 +201,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download git-annex package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: git-annex-macos-dmg_${{ needs.build-package.outputs.build-version }}
 
@@ -291,7 +291,7 @@ jobs:
 
       - name: Send e-mail on failed scheduled run
         if: "failure() && github.event_name == 'schedule'"
-        uses: dawidd6/action-send-mail@v2
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: ${{ secrets.NOTIFY_SMTP_HOST }}
           server_port: ${{ secrets.NOTIFY_SMTP_PORT }}
@@ -310,7 +310,7 @@ jobs:
     needs: build-package
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create pending PR status
         if: github.event.inputs.pr != ''
@@ -324,7 +324,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download git-annex package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: git-annex-macos-dmg_${{ needs.build-package.outputs.build-version }}
 
@@ -367,7 +367,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create pending PR status
         if: github.event.inputs.pr != ''
@@ -381,7 +381,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download git-annex package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: git-annex-macos-dmg_${{ needs.build-package.outputs.build-version }}
 
@@ -400,7 +400,7 @@ jobs:
           git config --global user.name "GitHub Almighty"
 
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
@@ -423,7 +423,7 @@ jobs:
 
       # needed for ssh certs under ubuntu and tox.ini everywhere
       - name: Checkout datalad
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: datalad/datalad
           path: datalad

--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Python 3.8+
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '^3.8'
 

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -32,7 +32,7 @@ jobs:
       build-version: ${{ steps.build-version.outputs.version }}
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -127,7 +127,7 @@ jobs:
         if: "!contains(env.DEB_BUILD_OPTIONS, 'nocheck')"
 
       - name: Upload packages
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: git-annex-debianstandalone-packages_${{ steps.build-version.outputs.version }}
           path: |
@@ -136,7 +136,7 @@ jobs:
 
       - name: Clone datalad/git-annex-ci-client-jobs
         if: github.event_name == 'schedule'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: datalad/git-annex-ci-client-jobs
           fetch-depth: 1
@@ -210,7 +210,7 @@ jobs:
 
       - name: Send e-mail on failed scheduled run
         if: "failure() && github.event_name == 'schedule'"
-        uses: dawidd6/action-send-mail@v2
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: ${{ secrets.NOTIFY_SMTP_HOST }}
           server_port: ${{ secrets.NOTIFY_SMTP_PORT }}
@@ -234,7 +234,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create pending PR status
         if: github.event.inputs.pr != ''
@@ -248,7 +248,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download git-annex package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: git-annex-debianstandalone-packages_${{ needs.build-package.outputs.build-version }}
 
@@ -332,7 +332,7 @@ jobs:
 
       - name: Send e-mail on failed scheduled run
         if: "failure() && github.event_name == 'schedule'"
-        uses: dawidd6/action-send-mail@v2
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: ${{ secrets.NOTIFY_SMTP_HOST }}
           server_port: ${{ secrets.NOTIFY_SMTP_PORT }}
@@ -351,7 +351,7 @@ jobs:
     needs: build-package
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create pending PR status
         if: github.event.inputs.pr != ''
@@ -365,7 +365,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download git-annex package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: git-annex-debianstandalone-packages_${{ needs.build-package.outputs.build-version }}
 
@@ -405,7 +405,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create pending PR status
         if: github.event.inputs.pr != ''
@@ -419,7 +419,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download git-annex package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: git-annex-debianstandalone-packages_${{ needs.build-package.outputs.build-version }}
 
@@ -442,7 +442,7 @@ jobs:
           git config --global user.name "GitHub Almighty"
 
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
@@ -465,7 +465,7 @@ jobs:
 
       # needed for ssh certs under ubuntu and tox.ini everywhere
       - name: Checkout datalad
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: datalad/datalad
           path: datalad

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -29,7 +29,7 @@ jobs:
       build-version: ${{ steps.build-version.outputs.version }}
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -45,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Haskell
-        uses: actions/setup-haskell@v1.1.3
+        uses: haskell/actions/setup@v2
         with:
           enable-stack: true
           stack-no-global: true
@@ -114,7 +114,7 @@ jobs:
       # At this point, stack.yaml.lock exists, so we can activate the cache
 
       - name: Enable Stack cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: 'C:\sr\snapshots'
           key: cache-stack-windows-${{ hashFiles('stack.yaml.lock') }}-${{ hashFiles('git-annex.cabal') }}
@@ -144,7 +144,7 @@ jobs:
              git-annex-installer_"${{ steps.build-version.outputs.version }}".exe
 
       - name: Upload packages
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: git-annex-windows-installer_${{ steps.build-version.outputs.version }}
           path: |
@@ -191,7 +191,7 @@ jobs:
 
       - name: Send e-mail on failed scheduled run
         if: "failure() && github.event_name == 'schedule'"
-        uses: dawidd6/action-send-mail@v2
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: ${{ secrets.NOTIFY_SMTP_HOST }}
           server_port: ${{ secrets.NOTIFY_SMTP_PORT }}
@@ -215,7 +215,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create pending PR status
         if: github.event.inputs.pr != ''
@@ -229,7 +229,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download git-annex package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: git-annex-windows-installer_${{ needs.build-package.outputs.build-version }}
 
@@ -289,7 +289,7 @@ jobs:
 
       - name: Send e-mail on failed scheduled run
         if: "failure() && github.event_name == 'schedule'"
-        uses: dawidd6/action-send-mail@v2
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: ${{ secrets.NOTIFY_SMTP_HOST }}
           server_port: ${{ secrets.NOTIFY_SMTP_PORT }}
@@ -312,7 +312,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create pending PR status
         if: github.event.inputs.pr != ''
@@ -326,7 +326,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download git-annex package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: git-annex-windows-installer_${{ needs.build-package.outputs.build-version }}
 
@@ -394,7 +394,7 @@ jobs:
           git config --global user.name "GitHub Almighty"
 
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
@@ -417,7 +417,7 @@ jobs:
 
       # needed for ssh certs under ubuntu and tox.ini everywhere
       - name: Checkout datalad
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: datalad/datalad
           path: datalad

--- a/.github/workflows/daily-status.yaml
+++ b/.github/workflows/daily-status.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '^3.8'
 

--- a/.github/workflows/template/build-{{ostype}}.yaml.j2
+++ b/.github/workflows/template/build-{{ostype}}.yaml.j2
@@ -33,7 +33,7 @@ jobs:
       build-version: ${{ steps.build-version.outputs.version }}
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -62,7 +62,7 @@ jobs:
 
     {% elif ostype == "windows" %}
       - name: Setup Haskell
-        uses: actions/setup-haskell@v1.1.3
+        uses: haskell/actions/setup@v2
         with:
           enable-stack: true
           stack-no-global: true
@@ -172,7 +172,7 @@ jobs:
         run: stack setup
 
       - name: Enable Stack cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.stack
           key: cache-stack-macos-${{ hashFiles('stack.yaml.lock') }}-${{ hashFiles('git-annex.cabal') }}
@@ -220,7 +220,7 @@ jobs:
       # At this point, stack.yaml.lock exists, so we can activate the cache
 
       - name: Enable Stack cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: 'C:\sr\snapshots'
           key: cache-stack-windows-${{ hashFiles('stack.yaml.lock') }}-${{ hashFiles('git-annex.cabal') }}
@@ -251,7 +251,7 @@ jobs:
 
     {% endif %}
       - name: Upload packages
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: {{artifact_basename}}_${{ steps.build-version.outputs.version }}
           path: |
@@ -269,7 +269,7 @@ jobs:
       {% endif %}
       - name: Clone datalad/git-annex-ci-client-jobs
         if: github.event_name == 'schedule'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: datalad/git-annex-ci-client-jobs
           fetch-depth: 1
@@ -344,7 +344,7 @@ jobs:
 
       - name: Send e-mail on failed scheduled run
         if: "failure() && github.event_name == 'schedule'"
-        uses: dawidd6/action-send-mail@v2
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: ${{ secrets.NOTIFY_SMTP_HOST }}
           server_port: ${{ secrets.NOTIFY_SMTP_PORT }}
@@ -376,7 +376,7 @@ jobs:
   {% endif %}
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create pending PR status
         if: github.event.inputs.pr != ''
@@ -394,7 +394,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download git-annex package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: {{artifact_basename}}_${{ needs.build-package.outputs.build-version }}
 
@@ -507,7 +507,7 @@ jobs:
 
       - name: Send e-mail on failed scheduled run
         if: "failure() && github.event_name == 'schedule'"
-        uses: dawidd6/action-send-mail@v2
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: ${{ secrets.NOTIFY_SMTP_HOST }}
           server_port: ${{ secrets.NOTIFY_SMTP_PORT }}
@@ -531,7 +531,7 @@ jobs:
     needs: build-package
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create pending PR status
         if: github.event.inputs.pr != ''
@@ -545,7 +545,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download git-annex package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: {{artifact_basename}}_${{ needs.build-package.outputs.build-version }}
 
@@ -592,7 +592,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create pending PR status
         if: github.event.inputs.pr != ''
@@ -606,7 +606,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download git-annex package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: {{artifact_basename}}_${{ needs.build-package.outputs.build-version }}
 
@@ -701,7 +701,7 @@ jobs:
           git config --global user.name "GitHub Almighty"
 
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
@@ -724,7 +724,7 @@ jobs:
 
       # needed for ssh certs under ubuntu and tox.ini everywhere
       - name: Checkout datalad
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: datalad/datalad
           path: datalad

--- a/.github/workflows/update-mirror.yml
+++ b/.github/workflows/update-mirror.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: upstream/master
@@ -35,7 +35,7 @@ jobs:
         run: git checkout origin/master -- .github
 
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '^3.6'
 


### PR DESCRIPTION
We are currently using older versions of the updated GitHub Actions actions, and these older versions still use Node 12, [which is deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).

This PR also configures Dependabot to create PRs updating workflows whenever a new version of a used action is released, as discussed in https://github.com/datalad/datalad-extensions/pull/105.