### PR TITLE
Copy, not move, stack-lts-18.13.yaml over stack.yml

### DIFF
--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -101,7 +101,7 @@ jobs:
         run: |
           # Need to use that LTS ATM on Windows
           # ref: https://github.com/datalad/git-annex/issues/168#issuecomment-1665910564
-          mv stack-lts-18.13.yaml stack.yaml
+          cp stack-lts-18.13.yaml stack.yaml
           perl -pli -e 's/magicmime: false/magicmime: true/' stack.yaml
 
       - name: Set UPGRADE_LOCATION

--- a/.github/workflows/template/build-{{ostype}}.yaml.j2
+++ b/.github/workflows/template/build-{{ostype}}.yaml.j2
@@ -219,7 +219,7 @@ jobs:
         run: |
           # Need to use that LTS ATM on Windows
           # ref: https://github.com/datalad/git-annex/issues/168#issuecomment-1665910564
-          mv stack-lts-18.13.yaml stack.yaml
+          cp stack-lts-18.13.yaml stack.yaml
           perl -pli -e 's/magicmime: false/magicmime: true/' stack.yaml
 
       - name: Set UPGRADE_LOCATION


### PR DESCRIPTION
Since now that file is also included in git-annex.cabal for source distribution so we better not remove it.

Paying the price for a dirty fix.

@joeyh do you foresee use of that `stack-lts-18.13.yaml` for windows for an extended period of time?  I wonder if I should stop being "lazy" and follow @jkniiv in https://github.com/datalad/git-annex/pull/169#issuecomment-1670200241 to properly parametrize specification of stack*.yaml file to be used?