### PR TITLE
testannex.py: Fix arguments to `os.execl`

### DIFF
--- a/clients/testannex.py
+++ b/clients/testannex.py
@@ -132,7 +132,7 @@ def main(clientid: str, jobdir: Path, log_level: int) -> None:
     GitRepo(this_script.parent).run("-c", "pull.rebase=false", "pull", "origin", "master")
     if this_script.stat().st_mtime_ns > mtime:
         log.info("This script was modified; restarting ...")
-        os.execl(sys.executable, __file__, *sys.argv[1:])
+        os.execl(sys.executable, sys.executable, __file__, *sys.argv[1:])
 
     cfg = parse_clients()
     try:


### PR DESCRIPTION
See also: the cronjob that just failed on ndoli.