### PR TITLE
Exclude VCS files et al. from Debian source package; explicitly declare Debian source format version

### DIFF
--- a/patches/20240213-3475b09c3e-exclude-git.patch
+++ b/patches/20240213-3475b09c3e-exclude-git.patch
@@ -1,3 +1,10 @@
+diff --git a/debian/source/format b/debian/source/format
+new file mode 100644
+index 0000000000..d3827e75a5
+--- /dev/null
++++ b/debian/source/format
+@@ -0,0 +1 @@
++1.0
 diff --git a/debian/source/options b/debian/source/options
 new file mode 100644
 index 0000000000..62612d7c71

--- a/patches/20240213-3475b09c3e-exclude-git.patch
+++ b/patches/20240213-3475b09c3e-exclude-git.patch
@@ -1,0 +1,7 @@
+diff --git a/debian/source/options b/debian/source/options
+new file mode 100644
+index 0000000000..8217775d01
+--- /dev/null
++++ b/debian/source/options
+@@ -0,0 +1 @@
++tar-ignore = ".git"

--- a/patches/20240213-3475b09c3e-exclude-git.patch
+++ b/patches/20240213-3475b09c3e-exclude-git.patch
@@ -1,7 +1,17 @@
 diff --git a/debian/source/options b/debian/source/options
 new file mode 100644
-index 0000000000..8217775d01
+index 0000000000..62612d7c71
 --- /dev/null
 +++ b/debian/source/options
-@@ -0,0 +1 @@
-+tar-ignore = ".git"
+@@ -0,0 +1,11 @@
++# Due to restrictions around allowed version strings, git-annex's Debian source
++# package has to use format 1.0, which doesn't ignore VCS files unless the
++# following explicit options are given:
++diff-ignore
++tar-ignore
++
++# Also ignore some trees specific to the datalad/git-annex build process:
++extend-diff-ignore = "(^|/)(\.github|clients|patches)($|/)"
++tar-ignore = .github
++tar-ignore = clients
++tar-ignore = patches


### PR DESCRIPTION
This PR adds a patch to `git-annex` that does the following:

- Configures the Debian source package builds to exclude common VCS files, along with excluding some non-`git-annex` files that are present for this repository's builds

    - Because all(?) builds done in this repository have a version with a nonzero component after the final hyphen, we cannot use the "3.0 (native)" format, which would enable these exclusions automatically, and using "3.0 (quilt)" instead would be needlessly complicated.  We thus have to stick with "1.0", which does not exclude VCS files unless we tell it to.

- Declares the Debian source package format to be "1.0"; declaring the format explicitly is highly recommended

@yarikoptic Once we confirm this works properly, we should submit this patch upstream to @joeyh.