### PR TITLE
Revert "Explicitly specify 1.0 Debian source format"

### DIFF
--- a/patches/20240213-3475b09c3e-exclude-git.patch
+++ b/patches/20240213-3475b09c3e-exclude-git.patch
@@ -1,10 +1,3 @@
-diff --git a/debian/source/format b/debian/source/format
-new file mode 100644
-index 0000000000..d3827e75a5
---- /dev/null
-+++ b/debian/source/format
-@@ -0,0 +1 @@
-+1.0
 diff --git a/debian/source/options b/debian/source/options
 new file mode 100644
 index 0000000000..62612d7c71


### PR DESCRIPTION
This reverts commit 5500e5f373914362763cb690c664d53fae635d14.

Fixes #199.

@joeyh added a `debian/source/format` file to git-annex's source in commit d7ce073227, but the `debian/source/options` file was not added, thereby causing the application of the patch from #197 to fail.  This PR removes `debian/source/format` from the patch, thereby fixing the build failure.