### PR TITLE
Update macos-11 runners to macos-12

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build-package:
-    runs-on: macos-11
+    runs-on: macos-12
     outputs:
       build-version: ${{ steps.build-version.outputs.version }}
     steps:
@@ -183,7 +183,7 @@ jobs:
     strategy:
       matrix:
         flavor: ["normal", "crippled-tmp", "custom-config1"]
-        os: [macos-11]
+        os: [macos-12]
         include: [{"flavor": "normal", "os": "macos-latest"}]
       fail-fast: false
     steps:
@@ -307,7 +307,7 @@ jobs:
             See <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}> for more information.
 
   test-annex-more:
-    runs-on: macos-11
+    runs-on: macos-12
     needs: build-package
     steps:
       - name: Checkout this repository
@@ -360,7 +360,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test-datalad:
-    runs-on: macos-11
+    runs-on: macos-12
     needs: build-package
     strategy:
       matrix:

--- a/.github/workflows/template/specs.yml
+++ b/.github/workflows/template/specs.yml
@@ -18,7 +18,7 @@
 - ostype: macos
   osname: macOS
   cron_hour: '01'
-  runs_on: macos-11
+  runs_on: macos-12
   env:
     LANG: C
   test_annex_flavors: [normal, crippled-tmp, custom-config1]


### PR DESCRIPTION
["The macOS 11 runner image will be removed on 6/28/2024."](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/).