### PR TITLE
A few more of new dependencies for git-annex build env

### DIFF
--- a/.github/workflows/tools/containers/buildenv-git-annex/Dockerfile
+++ b/.github/workflows/tools/containers/buildenv-git-annex/Dockerfile
@@ -27,7 +27,7 @@ RUN set -ex; \
     export DEBIAN_FRONTEND=noninteractive; \
     apt-get build-dep -y -q git-annex-standalone; \
     # Needed additional build-depends which might have not yet in "released" version
-    apt-get install -y libghc-criterion-dev libghc-http-client-restricted-dev libghc-git-lfs-dev; \
+    apt-get install -y libghc-criterion-dev libghc-http-client-restricted-dev libghc-git-lfs-dev libghc-servant-dev libghc-servant-server-dev libghc-servant-client-dev libghc-servant-client-core-dev; \
     # Needed additional tools
     apt-get install -y devscripts quilt; \
     # Some helper utilities just in case


### PR DESCRIPTION
Image build could potentially fail (here or on master) so I will need to watch it. Should eventually succeed, dunno why yet but a fix (I think) was just merged in https://github.com/neurodebian/neurodebian/pull/94 and I am building updated package, but not sure when / how to trigger update of neurodebian docker base images so will just retry a few times 