### PR TITLE
Switch to use singularity 4.1.4 instead of 3.10.4

### DIFF
--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -58,7 +58,7 @@ jobs:
         run: |
           # use if decide to get most recent release of singularity
           # release="$(gh api --jq .tag_name repos/sylabs/singularity/releases/latest)"
-          release="v3.10.4"
+          release="v4.1.4"
           codename="$(lsb_release -cs)"
           arch="$(dpkg --print-architecture)"
           cd /tmp

--- a/.github/workflows/template/build-{{ostype}}.yaml.j2
+++ b/.github/workflows/template/build-{{ostype}}.yaml.j2
@@ -60,7 +60,7 @@ jobs:
         run: |
           # use if decide to get most recent release of singularity
           # release="$(gh api --jq .tag_name repos/sylabs/singularity/releases/latest)"
-          release="v3.10.4"
+          release="v4.1.4"
           codename="$(lsb_release -cs)"
           arch="$(dpkg --print-architecture)"
           cd /tmp


### PR DESCRIPTION
Since there is no older version build for noble and GitHub upgraded to that newer Ubuntu.

Otherwise we started to fail builds on Ubuntu .