### PR TITLE
update github workflows to use newer stack

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -48,7 +48,7 @@ jobs:
         run: brew install libmagic pkg-config rsync
 
       - name: Setup Haskell
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         with:
           enable-stack: true
           stack-no-global: true

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -45,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Haskell
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         with:
           enable-stack: true
           stack-no-global: true

--- a/.github/workflows/template/build-{{ostype}}.yaml.j2
+++ b/.github/workflows/template/build-{{ostype}}.yaml.j2
@@ -77,7 +77,7 @@ jobs:
     {% endif %}
     {% if ostype == "windows" or ostype == "macos" %}
       - name: Setup Haskell
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         with:
           enable-stack: true
           stack-no-global: true


### PR DESCRIPTION
To avoid build failure like in
https://www.extrema.is/blog/2024/05/13/cabal-stack-initialbuildsteps-breakage when building with newer versions of ghc, a newer version of stack is needed.

The workflow was complaining about this change being needed:

	Warning: As of 2023-09-09, haskell/action/setup is no longer maintained, please switch to haskell-actions/setup (note: dash for slash).

See https://github.com/haskell-actions/setup

by @joeyh to address recent FTBFS on Windows and OSX.