### PR TITLE
ci: Switch to use macos-15-intel instead of -13

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build-package:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     outputs:
       build-version: ${{ steps.build-version.outputs.version }}
     steps:
@@ -192,7 +192,7 @@ jobs:
     strategy:
       matrix:
         flavor: ["normal", "crippled-tmp", "custom-config1"]
-        os: [macos-13]
+        os: [macos-15-intel]
         include: [{"flavor": "normal", "os": "macos-latest"}]
       fail-fast: false
     steps:
@@ -329,7 +329,7 @@ jobs:
             See <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}> for more information.
 
   test-annex-more:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     needs: build-package
     steps:
       - name: Checkout this repository
@@ -382,7 +382,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test-datalad:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     needs: build-package
     strategy:
       matrix:

--- a/.github/workflows/template/specs.yml
+++ b/.github/workflows/template/specs.yml
@@ -18,7 +18,7 @@
 - ostype: macos
   osname: macOS
   cron_hour: '01'
-  runs_on: macos-13
+  runs_on: macos-15-intel
   env:
     LANG: C
   test_annex_flavors: [normal, crippled-tmp, custom-config1]


### PR DESCRIPTION
We managed to miss builds starting early Dec when -13 was entirely deprecated. And thus managed to miss latest release of git-annex and now causing broken test run installs in CI for datalad.
