### PR TITLE
Add patch to URL-escape key paths in HTTP remote URLs

### DIFF
--- a/patches/20260212-43a3f3aaf2-url-escape-keyUrls.patch
+++ b/patches/20260212-43a3f3aaf2-url-escape-keyUrls.patch
@@ -1,0 +1,18 @@
+diff --git a/Remote/Git.hs b/Remote/Git.hs
+index 6b7dc77d98..4faaea082d 100644
+--- a/Remote/Git.hs
++++ b/Remote/Git.hs
+@@ -482,7 +482,12 @@ inAnnex' repo rmt st@(State connpool duc _ _ _ _) key
+ keyUrls :: GitConfig -> Git.Repo -> Remote -> Key -> [String]
+ keyUrls gc repo r key = map tourl locs'
+   where
+-	tourl l = Git.repoLocation repo ++ "/" ++ l
++	tourl l = Git.repoLocation repo ++ "/" ++ escapeURIString escchar l
++	-- Escape characters that are not allowed unescaped in a URI
++	-- path component, but don't escape '/' since the location
++	-- is a path with multiple components.
++	escchar '/' = True
++	escchar c = isUnescapedInURIComponent c
+ 	-- If the remote is known to not be bare, try the hash locations
+ 	-- used for non-bare repos first, as an optimisation.
+ 	locs


### PR DESCRIPTION
keyUrls in Remote/Git.hs constructs URLs for fetching content from HTTP git remotes by simple string concatenation of the repo URL and the annex object path.  When the key contains characters that keyFile encodes using git-annex's internal escaping (& for colons, % for slashes), the resulting URL contains bare % and & characters that are invalid in a URI path -- % must be followed by two hex digits per RFC 3986, and the parser rejects the URL as "invalid url".

This affects URL-backend keys like
URL--yt:https://www.youtube.com/watch?v=... where keyFile produces paths containing &c (for :) and %% (for //), resulting in unparseable URLs.  SHA256E and other hash-based keys are unaffected since their serialized forms contain only URI-safe characters.

The fix applies escapeURIString (from Network.URI, already imported) to percent-encode the path components while preserving / as a path separator.  This is the same approach used by Remote/S3.hs and Remote/WebDAV/DavLocation.hs.

See https://git-annex.branchable.com/bugs/fails_to_get_from_apache2_server_URL_backend_file/