### PR TITLE
Switch to forky and progress freeze date to recent

### DIFF
--- a/.github/workflows/tools/containers/buildenv-git-annex/Dockerfile
+++ b/.github/workflows/tools/containers/buildenv-git-annex/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie
+FROM debian:forky
 
 # Apparently snapshots.debian.org has heavy rate limiting policy so we better
 # provide some apt conf tune ups with hope to make apt more robust in talking to it
@@ -21,7 +21,7 @@ RUN echo 'Acquire::http::Dl-Limit "200";' >| /etc/apt/apt.conf.d/20snapshots \
 RUN set -ex; \
     apt update; \
     apt install neurodebian-freeze; \
-    nd_freeze 20250819; \
+    nd_freeze 20260425; \
     f=/etc/apt/sources.list.d/debian.sources; if [ -e "$f" ] && ! grep -q "^URIs:.*snapshot\." "$f"; then mv "$f" "$f.disabled"; fi; \
     sed -i -e 's,\(^deb\) \(.*\),\1 \2\ndeb-src \2,g' /etc/apt/sources.list.d/*.list; \
     apt-get update -qq; \


### PR DESCRIPTION
- Closes https://github.com/datalad/git-annex/issues/258

I now verified that building exactly the same master of git-annex with 'stable debian' image vs 'forky', what differs it in terms of making it to not stall p2phttp interaction. And the differences are:

	❯ diff -Naur <( PATH=/home/yoh/proj/git-annex-build-fresh1:$PATH git-annex version ) <( PATH=/home/yoh/proj/git-annex-build-forky1:$PATH git-annex version )
	--- /proc/self/fd/18	2026-04-30 17:06:49.664635907 -0400
	+++ /proc/self/fd/19	2026-04-30 17:06:49.664635907 -0400
	@@ -1,6 +1,6 @@
	 git-annex version: 10.20260422-g70d04496e485bc650405f125c4ee43208dce0b17
	 build flags: Assistant Webapp Inotify DBus DesktopNotify TorrentParser MagicMime Benchmark Feeds Testsuite S3 WebDAV Servant
	-dependency versions: aws-0.24.1 bloomfilter-2.0.1.2 crypton-0.34 DAV-1.3.4 feed-1.3.2.1 ghc-9.6.6 http-client-0.7.17 torrent-10000.1.3 uuid-1.3.15 yesod-1.6.2.1
	+dependency versions: aws-0.24.4 bloomfilter-2.0.1.3 crypton-1.0.4 DAV-1.3.4 feed-1.3.2.1 ghc-9.10.3 http-client-0.7.19 torrent-10000.1.3 uuid-1.3.16 yesod-1.6.2.1
	 key/value backends: SHA256E SHA256 SHA512E SHA512 SHA224E SHA224 SHA384E SHA384 SHA3_256E SHA3_256 SHA3_512E SHA3_512 SHA3_224E SHA3_224 SHA3_384E SHA3_384 SKEIN256E SKEIN256 SKEIN512E SKEIN512 BLAKE2B256E BLAKE2B256 BLAKE2B512E BLAKE2B512 BLAKE2B160E BLAKE2B160 BLAKE2B224E BLAKE2B224 BLAKE2B384E BLAKE2B384 BLAKE2BP512E BLAKE2BP512 BLAKE2S256E BLAKE2S256 BLAKE2S160E BLAKE2S160 BLAKE2S224E BLAKE2S224 BLAKE2SP256E BLAKE2SP256 BLAKE2SP224E BLAKE2SP224 SHA1E SHA1 MD5E MD5 WORM URL GITBUNDLE GITMANIFEST VURL X*
	 remote types: git gcrypt p2p S3 bup directory rsync web bittorrent webdav adb tahoe glacier ddar git-lfs httpalso borg rclone hook external compute mask
	 operating system: linux x86_64