### PR TITLE
CI diagnostic: Windows test_cli_configoverrides failure

### DIFF
--- a/.github/workflows/build-macos-arm64.yaml
+++ b/.github/workflows/build-macos-arm64.yaml
@@ -465,9 +465,11 @@ jobs:
 
       - name: Run datalad tests
         run: |
-          mkdir -p __testhome__
-          cd __testhome__
-          python -m pytest -c ../datalad/tox.ini -s -v --pyargs datalad
+          testhome="$PWD/__testhome__"
+          toxini="../datalad/tox.ini"
+          mkdir -p "$testhome"
+          cd "$testhome"
+          python -m pytest -c "$toxini" -s -v --pyargs datalad
 
       - name: Set final PR status
         if: always() && github.event.inputs.pr != ''

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -464,9 +464,11 @@ jobs:
 
       - name: Run datalad tests
         run: |
-          mkdir -p __testhome__
-          cd __testhome__
-          python -m pytest -c ../datalad/tox.ini -s -v --pyargs datalad
+          testhome="$PWD/__testhome__"
+          toxini="../datalad/tox.ini"
+          mkdir -p "$testhome"
+          cd "$testhome"
+          python -m pytest -c "$toxini" -s -v --pyargs datalad
 
       - name: Set final PR status
         if: always() && github.event.inputs.pr != ''

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -510,9 +510,11 @@ jobs:
 
       - name: Run datalad tests
         run: |
-          mkdir -p __testhome__
-          cd __testhome__
-          python -m pytest -c ../datalad/tox.ini -s -v --pyargs datalad
+          testhome="$PWD/__testhome__"
+          toxini="../datalad/tox.ini"
+          mkdir -p "$testhome"
+          cd "$testhome"
+          python -m pytest -c "$toxini" -s -v --pyargs datalad
 
       - name: Set final PR status
         if: always() && github.event.inputs.pr != ''

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -439,9 +439,17 @@ jobs:
 
       - name: Run datalad tests
         run: |
-          mkdir -p __testhome__
-          cd __testhome__
-          python -m pytest -c ../datalad/tox.ini -s -v --pyargs datalad
+          # windows-2025: HOME and default tempfile live on C: while the
+          # actions workspace is on D:.  Any datalad code that computes
+          # `os.path.relpath(some_C_path, some_D_path)` raises
+          # `ValueError: path is on mount 'D:', start on mount 'C:'`.
+          # Run pytest from a C: directory so tempdir + HOME + CWD all
+          # share one drive.  See commit message for context.
+          testhome="$HOME/dl-testhome"
+          toxini="$GITHUB_WORKSPACE/datalad/tox.ini"
+          mkdir -p "$testhome"
+          cd "$testhome"
+          python -m pytest -c "$toxini" -s -v --pyargs datalad
 
       - name: Set final PR status
         if: always() && github.event.inputs.pr != ''

--- a/.github/workflows/template/build-{{ostype}}.yaml.j2
+++ b/.github/workflows/template/build-{{ostype}}.yaml.j2
@@ -772,9 +772,22 @@ jobs:
     {% endif %}
       - name: Run datalad tests
         run: |
-          mkdir -p __testhome__
-          cd __testhome__
-          python -m pytest -c ../datalad/tox.ini -s -v --pyargs datalad
+          {% if ostype == "windows" %}
+          # windows-2025: HOME and default tempfile live on C: while the
+          # actions workspace is on D:.  Any datalad code that computes
+          # `os.path.relpath(some_C_path, some_D_path)` raises
+          # `ValueError: path is on mount 'D:', start on mount 'C:'`.
+          # Run pytest from a C: directory so tempdir + HOME + CWD all
+          # share one drive.  See commit message for context.
+          testhome="$HOME/dl-testhome"
+          toxini="$GITHUB_WORKSPACE/datalad/tox.ini"
+          {% else %}
+          testhome="$PWD/__testhome__"
+          toxini="../datalad/tox.ini"
+          {% endif %}
+          mkdir -p "$testhome"
+          cd "$testhome"
+          python -m pytest -c "$toxini" -s -v --pyargs datalad
 
       - name: Set final PR status
         if: always() && github.event.inputs.pr != ''


### PR DESCRIPTION
> [!IMPORTANT]
> Drop the TEMP commit before merge.

## Summary

Windows `test-datalad` fails on a single test — `test_cli_configoverrides` — which passes on Ubuntu with the same git-annex and on datalad's own AppVeyor Windows CI with an *older* git-annex (10.20230126, 2023‑01). The failure is `assert 1 == 0` (datalad `run` exits 1), but pytest patches stdout/stderr so the actual error never reaches the log.

This PR adds a diagnostic step that reproduces the failing invocation outside pytest so we can see exit code + stderr, and temporarily scopes the Windows CI down so iteration is ~2 min instead of ~90.

Once we have signal, next step is likely to bisect git-annex.

## Commits

- 10cfa9e4b2 `CI: add Windows diagnostic for datalad test_cli_configoverrides failure`
- 5feffcda0f `TEMP: shrink Windows CI to only the failing datalad test — REVERT BEFORE MERGE`

## Test plan

- [ ] Windows CI runs the new diagnostic step and prints exit codes / stderr for the three attempts
- [ ] Root-cause identified (git-annex regression? Windows Server 2025 quirk? datalad Windows-side bug?)
- [ ] Drop TEMP commit `5feffcda0f` before merge
